### PR TITLE
fix: Strip whitespace from input

### DIFF
--- a/play.py
+++ b/play.py
@@ -34,7 +34,7 @@ def play_level(level, data):
                    "examine": look}
     printer.welcome_level(level)
     while data["playing_level"]:
-        inp = input("> ").lower()
+        inp = input("> ").lower().strip()
         if inp in actions.keys():
             actions[inp](data)
             continue
@@ -99,7 +99,7 @@ def roll(data):
     place = data["level"]["location"]
     items = data["level"]["grid"][place[1]][place[0]]
     item_names = [item["name"].lower() for item in items]
-    to_roll = input("Roll what? ").lower()
+    to_roll = input("Roll what? ").lower().strip()
     targets = [item for item in items if item["name"].lower() == to_roll]
     if len(targets) > 0:
         item = targets[0]
@@ -183,7 +183,7 @@ def look(data):
                    "h": (0, 0)}
     katamari = {"katamari" : ""}
     prompt = "N, S, E, W, Here, or Katamari"
-    inp = input("look which direction? ({0}) ".format(prompt)).lower()
+    inp = input("look which direction? ({0}) ".format(prompt)).lower().strip()
     if inp in options.keys():
         look_at(options[inp], data)
     elif inp in alt_options.keys():


### PR DESCRIPTION
While furiously typing input (while not understanding the timing
mechanism) there was a tendency to add extra whitespace.  As it doesn't
seem to be working against the spirit of the gameplay I added a strip()
function to each of the input calls to further normalize the input
beyond just rendering lowercase.

Signed-Off: Brian 'redbeard' Harrington redbeard@dead-city.org
