### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language="python3"
+run="python main.py"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Katamari Adventure
 A text adventure de-make of Katamari Damacy inspired by [this post](http://katamari-damacy.livejournal.com/262676.html)
 
+[![Run on Repl.it](https://repl.it/badge/github/SwartzCr/katamari)](https://repl.it/github/SwartzCr/katamari)
+
 # Play!
 To play simply clone the directory and run `python main.py`  
 Now with tab completion! (thanks @rolandshoemaker)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@joshwood/katamari).